### PR TITLE
Handle brms categorical models with a weight variable

### DIFF
--- a/R/get_predictions_stan.R
+++ b/R/get_predictions_stan.R
@@ -82,7 +82,7 @@ get_predictions_stan <- function(model, fitfram, ci.lvl, type, faminfo, ppd, ter
       purrr::map_df(stats::median) %>%
       .gather(key = "grp", value = "predicted")
 
-    resp.vals <- levels(insight::get_response(model))
+    resp.vals <- levels(insight::get_response(model)[[1]])
     term.cats <- nrow(fitfram)
     fitfram <- purrr::map_df(1:length(resp.vals), ~ fitfram)
 


### PR DESCRIPTION
There seems to be a bug when running ggpredict() for brms with family=categorical and a weight variable. 

Minimal example:

```R
library(brms)
library(ggeffects)

x <- sample(c(1:3), 1000, replace = T)
w <- runif(1000, min = 0.3, max = 3)
y <- rnorm(1000, mean = 0, sd = 1)

data <- data.frame(x,w,y)
data$x <- factor(data$x)

m <- brm(x | weights(w) ~ y, data = data, family = categorical, chains = 1, iter = 500)

ggpredict(m, 'y')
```
Results in:
```
Error in `$<-.data.frame`(`*tmp*`, "predicted", value = c(0.344617761211488,  : 
  replacement has 24 rows, data has 16
In addition: There were 24 warnings (use warnings() to see them)
```

The actual bug may be in the insight package. insight::get_response() is returning both the response and weight variable. However, this was a fairly easy workaround, so I figured you can decide whether or not to accept it.