### PR TITLE
Adds rawdata attribute to ggemmeans()-output. Resolves #108

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,10 @@ Type: Package
 Encoding: UTF-8
 Title: Create Tidy Data Frames of Marginal Effects for 'ggplot' from Model Outputs
 Version: 0.13.0
-Authors@R: person("Daniel", "Lüdecke", role = c("aut", "cre"), email = "d.luedecke@uke.de", comment = c(ORCID = "0000-0002-8895-3206"))
+Authors@R: c(
+      person("Daniel", "Lüdecke", role = c("aut", "cre"), email = "d.luedecke@uke.de", comment = c(ORCID = "0000-0002-8895-3206")),
+      person("Frederik", "Aust", role = "ctb", comment = c(ORCID = "0000-0003-4900-788X"))
+    )
 Maintainer: Daniel Lüdecke <d.luedecke@uke.de>
 Description: Compute marginal effects from statistical models and returns the 
     result as tidy data frames. These data frames are ready to use with the 

--- a/R/ggemmeans.R
+++ b/R/ggemmeans.R
@@ -132,6 +132,9 @@ ggemmeans <- function(model,
 
   attr(mydf, "model.name") <- model.name
 
+  # add raw data as well
+  attr(mydf, "rawdata") <- .get_raw_data(model, ori.fram, cleaned.terms)
+
   .post_processing_labels(
     model = model,
     mydf = mydf,


### PR DESCRIPTION
# Description

This PR aims at adding a `rawdata` attribute to the output of `ggemmeans()`.

# Proposed Changes

I added the corresponding line from `ggpredict()` to `ggemmeans()`. The following code now plots the model predictions and raw data:

~~~r
plot(ggemmeans(lm(dist ~ speed, cars), term = "speed"), rawdata = TRUE)
~~~
