### PR TITLE
[WIP] Implements continuous color and fill scale for continuous "grouping" variables

### DIFF
--- a/R/ggeffect.R
+++ b/R/ggeffect.R
@@ -265,6 +265,12 @@ ggeffect_helper <- function(model, terms, ci.lvl, ...) {
   # convert to data frame
   result <- as.data.frame(tmp, stringsAsFactors = FALSE)
 
+  if(length(terms) > 1) {
+    attr(result, "continuous.group") <- is.numeric(original_model_frame[[terms[2]]]) & is.null(attr(original_model_frame[[terms[2]]], "labels"))
+  } else {
+    attr(result, "continuous.group") <- FALSE
+  }
+
   # add raw data as well
   attr(result, "rawdata") <- .get_raw_data(model, original_model_frame, terms)
 

--- a/R/ggemmeans.R
+++ b/R/ggemmeans.R
@@ -87,10 +87,10 @@ ggemmeans <- function(model,
     }
   }
 
-  attr(prediction_data, "continuous.group") <- attr(data_grid, "continuous.group")
-
   # return NULL on error
   if (is.null(prediction_data)) return(NULL)
+
+  attr(prediction_data, "continuous.group") <- attr(data_grid, "continuous.group")
 
   if (model_info$is_ordinal | model_info$is_categorical) {
     colnames(prediction_data)[1] <- "response.level"

--- a/R/ggemmeans.R
+++ b/R/ggemmeans.R
@@ -87,6 +87,8 @@ ggemmeans <- function(model,
     }
   }
 
+  attr(prediction_data, "continuous.group") <- attr(data_grid, "continuous.group")
+
   # return NULL on error
   if (is.null(prediction_data)) return(NULL)
 

--- a/R/ggpredict.R
+++ b/R/ggpredict.R
@@ -576,10 +576,10 @@ ggpredict_helper <- function(model,
     ...
   )
 
-  attr(prediction_data, "continuous.group") <- attr(data_grid, "continuous.group")
-
   # return if no predicted values have been computed
   if (is.null(prediction_data)) return(NULL)
+
+  attr(prediction_data, "continuous.group") <- attr(data_grid, "continuous.group")
 
   # for survival probabilities or cumulative hazards, we need
   # the "time" variable

--- a/R/ggpredict.R
+++ b/R/ggpredict.R
@@ -576,6 +576,8 @@ ggpredict_helper <- function(model,
     ...
   )
 
+  attr(prediction_data, "continuous.group") <- attr(data_grid, "continuous.group")
+
   # return if no predicted values have been computed
   if (is.null(prediction_data)) return(NULL)
 

--- a/R/post_processing_predictions.R
+++ b/R/post_processing_predictions.R
@@ -48,6 +48,8 @@
 
   attr(result, "legend.labels") <- legend.labels
   attr(result, "x.is.factor") <- x.is.factor
+  attr(result, "continuous.group") <- attr(prediction_data, "continuous.group") & is.null(attr(original_model_frame[[cleaned_terms[2]]], "labels"))
+
 
   result
 }

--- a/R/utils_colors.R
+++ b/R/utils_colors.R
@@ -1,5 +1,5 @@
 # get color palette
-.get_colors <- function(geom.colors, collen) {
+.get_colors <- function(geom.colors, collen, continuous) {
   # check for corrct color argument
   if (!is.null(geom.colors)) {
     geom.colors <- tolower(geom.colors)
@@ -11,6 +11,9 @@
     } else if (geom.colors[1] == "gs") {
       geom.colors <- ggeffects_pal(palette = "greyscale", n = collen)
       # do we have correct amount of colours?
+    } else if (length(geom.colors) > 1 & continuous) {
+      # preserve colors as is for latter use in gradient scale
+      return(geom.colors)
     } else if (length(geom.colors) > collen) {
       # shorten palette
       geom.colors <- geom.colors[1:collen]

--- a/R/utils_get_data_grid.R
+++ b/R/utils_get_data_grid.R
@@ -290,6 +290,11 @@
     # save constant values as attribute
     attr(focal_terms, "constant.values") <- constant_values
     attr(focal_terms, "n.trials") <- n.trials
+    if(length(terms) > 1) {
+      attr(focal_terms, "continuous.group") <- is.numeric(focal_terms[[2]])
+    } else {
+      attr(focal_terms, "continuous.group") <- FALSE
+    }
 
     return(focal_terms)
   }
@@ -376,6 +381,11 @@
   # save constant values as attribute
   attr(datlist, "constant.values") <- constant_values
   attr(datlist, "n.trials") <- n.trials
+  if(length(terms) > 1) {
+    attr(datlist, "continuous.group") <- is.numeric(datlist[[2]])
+  } else {
+    attr(datlist, "continuous.group") <- FALSE
+  }
 
   w <- insight::find_weights(model)
   if (!is.null(w) && !inherits(model, "brmsfit")) {

--- a/R/utils_get_data_grid.R
+++ b/R/utils_get_data_grid.R
@@ -290,7 +290,11 @@
     # save constant values as attribute
     attr(focal_terms, "constant.values") <- constant_values
     attr(focal_terms, "n.trials") <- n.trials
-    if(length(terms) > 1) {
+
+    # remember if grouping "factor" is numeric. this is possibly required
+    # later when plotting data points for continuous predictors that are
+    # held constant at their mean/sd values or similar.
+    if (length(terms) > 1) {
       attr(focal_terms, "continuous.group") <- is.numeric(focal_terms[[2]])
     } else {
       attr(focal_terms, "continuous.group") <- FALSE

--- a/R/utils_get_data_grid.R
+++ b/R/utils_get_data_grid.R
@@ -385,7 +385,11 @@
   # save constant values as attribute
   attr(datlist, "constant.values") <- constant_values
   attr(datlist, "n.trials") <- n.trials
-  if(length(terms) > 1) {
+
+  # remember if grouping "factor" is numeric. this is possibly required
+  # later when plotting data points for continuous predictors that are
+  # held constant at their mean/sd values or similar.
+  if (length(terms) > 1) {
     attr(datlist, "continuous.group") <- is.numeric(datlist[[2]])
   } else {
     attr(datlist, "continuous.group") <- FALSE


### PR DESCRIPTION
# Description

This PR aims at Implementing continuous color and fill scale for continuous "grouping" variables (see #110).

# Proposed Changes

The output of `ggpredict()`, `ggemmeans()`, and `ggeffect()` now has a new logical attribute `continuous.group`, which controls whether the color and fill scales are set to be continuous or discrete. The way I've implemented it so far continuous scales are only used when raw data is added to the plot.

The `colors` argument is handled slightly differently for continuous color scales: The predefined sets are used with `scale_*_gradientn()` to generate continuous color spaces. So if a continuous scale is used the user may pass fewer colors than there are grouping "levels" (but at least 2). See the fourth example below. If you agree with this behavior, I'll update the documentation accordingly.

~~~r
m <- lm(Sepal.Length ~ Petal.Length * Sepal.Width * Species, iris)

# Works without grouping variables
m_pred <- ggpredict(m, terms = "Petal.Length")
plot(m_pred, rawdata = TRUE)

# Works with continuous grouping variables
m_pred <- ggpredict(m, terms = c("Petal.Length", "Sepal.Width"))
plot(m_pred, rawdata = TRUE, dot.alpha = 1)

# Discrete color scale is used when raw data is omitted
plot(m_pred)

# Color control with continuous grouping variables
m_pred <- ggpredict(m, terms = c("Petal.Length", "Sepal.Width"))
plot(m_pred, rawdata = TRUE, dot.alpha = 1, colors = c("green", "blue"))

# Works with factorial grouping variables
m_pred <- ggpredict(m, terms = c("Petal.Length", "Species"))
plot(m_pred, rawdata = TRUE)

# Works with labelled "continuous" variables
data(efc)
fit <- lm(barthtot ~ c12hour + neg_c_7 + c161sex + c172code, data = efc)
dat <- ggpredict(fit, terms = c("c12hour", "c172code"))
plot(dat, rawdata = TRUE)
~~~

Let me know what you think.