### PR TITLE
Categorical/cumulative brms model fixes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,7 +5,8 @@ Title: Create Tidy Data Frames of Marginal Effects for 'ggplot' from Model Outpu
 Version: 0.15.0
 Authors@R: c(
       person("Daniel", "Lüdecke", role = c("aut", "cre"), email = "d.luedecke@uke.de", comment = c(ORCID = "0000-0002-8895-3206")),
-      person("Frederik", "Aust", role = "ctb", comment = c(ORCID = "0000-0003-4900-788X"))
+      person("Frederik", "Aust", role = "ctb", comment = c(ORCID = "0000-0003-4900-788X")),
+      person("Sam", "Crawley", role = "ctb", email = "sam@crawley.nz", comment = c(ORCID = "0000-0002-7847-0411"))
     )
 Maintainer: Daniel Lüdecke <d.luedecke@uke.de>
 Description: Compute marginal effects from statistical models and returns the 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # ggeffects 0.15.0
 
+## Bug fixes
+
+* Fixed some issues around categorical/cumulative brms models when the outcome is numeric
+
+# ggeffects 0.15.0
+
 ## Changes to functions
 
 * `ggpredict()` gets a new `type`-option, `"zi.prob"`, to predict the zero-inflation probability (for models from *pscl*, *glmmTMB* and *GLMMadaptive*).

--- a/R/get_predictions_stan.R
+++ b/R/get_predictions_stan.R
@@ -86,7 +86,16 @@ get_predictions_stan <- function(model, fitfram, ci.lvl, type, model_info, ppd, 
     rownames(tmp) <- NULL
     tmp$grp <- gsub("X", "", tmp$grp, fixed = TRUE)
 
-    resp.vals <- levels(insight::get_response(model)[[1]])
+    resp <- insight::get_response(model)
+    if (is.data.frame(resp))
+      resp <- resp[[1]] # Model must have been using weights
+
+    # Response could be a factor or numeric
+    if (is.factor(resp))
+      resp.vals <- levels(resp)
+    else
+      resp.vals <- unique(resp)
+
     term.cats <- nrow(fitfram)
 
     fitfram <- do.call(rbind, rep(list(fitfram), time = length(resp.vals)))

--- a/tests/testthat/test-brms-categ-cum.R
+++ b/tests/testthat/test-brms-categ-cum.R
@@ -1,0 +1,22 @@
+.runThisTest <- Sys.getenv("RunAllggeffectsTests") == "yes"
+
+if (.runThisTest && Sys.getenv("USER") != "travis") {
+  if (suppressWarnings(
+    require("testthat") &&
+    require("brms") &&
+    require("ggeffects") &&
+    require("insight")
+  )) {
+    m1 <- insight::download_model("brms_ordinal_1")
+    m2 <- insight::download_model("brms_ordinal_1_wt")
+    m3 <- insight::download_model("brms_categorical_1")
+    m4 <- insight::download_model("brms_categorical_1_wt")
+
+    test_that("ggpredict, brms-categ-cum", {
+      ggpredict(m1, c("mpg"))
+      ggpredict(m2, c("mpg"))
+      ggpredict(m3, c("mpg"))
+      ggpredict(m4, c("mpg"))
+    })
+  }
+}


### PR DESCRIPTION
Fixed some issues around categorical/cumulative brms models when the outcome is numeric (brms doesn't require the outcome to be a factor).

The additional tests require the new circus models to be merged (easystats/circus#9).