### PR TITLE
`pretty_range()` and `values_at()` can now also be used as function factories

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# ggeffects 1.0.1.001
+
+## General
+
+* `pretty_range()` and `values_at()` can now also be used as function factories.
+
 # ggeffects 1.0.1
 
 ## General

--- a/R/moderator_pattern.R
+++ b/R/moderator_pattern.R
@@ -19,74 +19,87 @@
 #'          }
 #'
 #' @return A numeric vector of length two or three, representing the required
-#'   values from \code{x}, like minimum/maximum value or mean and +/- 1 SD.
+#'   values from \code{x}, like minimum/maximum value or mean and +/- 1 SD. If
+#'   \code{x} is missing, a function, pre-programmed with \code{n} and
+#'   \code{length} is returned. See examples.
 #'
 #' @examples
 #' data(efc)
 #' values_at(efc$c12hour)
 #' values_at(efc$c12hour, "quart2")
 #'
+#' mean_sd <- values_at(values = "meansd")
+#' mean_sd(efc$c12hour)
+#'
 #' @importFrom stats sd quantile
 #' @export
 values_at <- function(x, values = "meansd") {
 
-  # check if representative value is possible to compute
-  # e.g. for quantiles, if we have at least three values
-  values <- check_rv(values, x)
+  force(values)
+  .values_at <- function(x) {
+    # check if representative value is possible to compute
+    # e.g. for quantiles, if we have at least three values
+    values <- check_rv(values, x)
 
-  # we have more than two values, so re-calculate effects, just using
-  # min and max value of moderator.
-  if (values == "minmax") {
-    # retrieve min and max values
-    mv.min <- min(x, na.rm = T)
-    mv.max <- max(x, na.rm = T)
-    # re-compute effects, prepare xlevels
-    xl <- c(mv.min, mv.max)
     # we have more than two values, so re-calculate effects, just using
-    # 0 and max value of moderator.
-  } else if (values == "zeromax") {
-    # retrieve max values
-    mv.max <- max(x, na.rm = T)
-    # re-compute effects, prepare xlevels
-    xl <- c(0, mv.max)
-    # compute mean +/- sd
-  } else if (values == "meansd") {
-    # retrieve mean and sd
-    mv.mean <- mean(x, na.rm = T)
-    mv.sd <- stats::sd(x, na.rm = T)
-    # re-compute effects, prepare xlevels
-    xl <- c(mv.mean - mv.sd, mv.mean, mv.mean + mv.sd)
-  } else if (values == "all") {
-    # re-compute effects, prepare xlevels
-    xl <- as.vector(unique(sort(x, na.last = NA)))
-  } else if (values == "quart") {
-    # re-compute effects, prepare xlevels
-    xl <- as.vector(stats::quantile(x, na.rm = T))
-  } else if (values == "quart2") {
-    # re-compute effects, prepare xlevels
-    xl <- as.vector(stats::quantile(x, na.rm = T))[2:4]
-  }
-
-  if (is.numeric(x)) {
-    if (is.whole(x)) {
-      rv <- round(xl, 1)
-      if (length(unique(rv)) < length(rv))
-        rv <- unique(round(xl, 2))
-    } else
-      rv <- round(xl, 2)
-
-    if (length(unique(rv)) < length(rv)) {
-      rv <- unique(round(xl, 3))
-      if (length(unique(rv)) < length(rv))
-        rv <- unique(round(xl, 4))
+    # min and max value of moderator.
+    if (values == "minmax") {
+      # retrieve min and max values
+      mv.min <- min(x, na.rm = T)
+      mv.max <- max(x, na.rm = T)
+      # re-compute effects, prepare xlevels
+      xl <- c(mv.min, mv.max)
+      # we have more than two values, so re-calculate effects, just using
+      # 0 and max value of moderator.
+    } else if (values == "zeromax") {
+      # retrieve max values
+      mv.max <- max(x, na.rm = T)
+      # re-compute effects, prepare xlevels
+      xl <- c(0, mv.max)
+      # compute mean +/- sd
+    } else if (values == "meansd") {
+      # retrieve mean and sd
+      mv.mean <- mean(x, na.rm = T)
+      mv.sd <- stats::sd(x, na.rm = T)
+      # re-compute effects, prepare xlevels
+      xl <- c(mv.mean - mv.sd, mv.mean, mv.mean + mv.sd)
+    } else if (values == "all") {
+      # re-compute effects, prepare xlevels
+      xl <- as.vector(unique(sort(x, na.last = NA)))
+    } else if (values == "quart") {
+      # re-compute effects, prepare xlevels
+      xl <- as.vector(stats::quantile(x, na.rm = T))
+    } else if (values == "quart2") {
+      # re-compute effects, prepare xlevels
+      xl <- as.vector(stats::quantile(x, na.rm = T))[2:4]
     }
-  } else {
-    rv <- xl
+
+    if (is.numeric(x)) {
+      if (is.whole(x)) {
+        rv <- round(xl, 1)
+        if (length(unique(rv)) < length(rv))
+          rv <- unique(round(xl, 2))
+      } else
+        rv <- round(xl, 2)
+
+      if (length(unique(rv)) < length(rv)) {
+        rv <- unique(round(xl, 3))
+        if (length(unique(rv)) < length(rv))
+          rv <- unique(round(xl, 4))
+      }
+    } else {
+      rv <- xl
+    }
+
+    rv
   }
 
-  rv
+  if (missing(x)) {
+    .values_at
+  } else {
+    .values_at(x)
+  }
 }
-
 
 #' @importFrom stats quantile
 check_rv <- function(values, x) {

--- a/man/pretty_range.Rd
+++ b/man/pretty_range.Rd
@@ -20,8 +20,9 @@ tries to find a pretty sequence.}
 intervals to be returned.}
 }
 \value{
-A numeric vector with a range corresponding to the minimum and maximum
-  values of \code{x}.
+A numeric vector with a range corresponding to the minimum and
+  maximum values of \code{x}. If \code{x} is missing, a function,
+  pre-programmed with \code{n} and \code{length} is returned. See examples.
 }
 \description{
 Creates an evenly spaced, pretty sequence of numbers for a
@@ -47,5 +48,9 @@ pretty_range(1:1000, length = 10)
 
 # same result
 pretty_range(1:1000, n = 2.5)
+
+# function factory
+range_n_5 <- pretty_range(n = 5)
+range_n_5(1:1000)
 
 }

--- a/man/values_at.Rd
+++ b/man/values_at.Rd
@@ -25,7 +25,9 @@ should be calculcated.
 }
 \value{
 A numeric vector of length two or three, representing the required
-  values from \code{x}, like minimum/maximum value or mean and +/- 1 SD.
+  values from \code{x}, like minimum/maximum value or mean and +/- 1 SD. If
+  \code{x} is missing, a function, pre-programmed with \code{n} and
+  \code{length} is returned. See examples.
 }
 \description{
 This function calculates representative values of a vector,
@@ -37,5 +39,8 @@ This function calculates representative values of a vector,
 data(efc)
 values_at(efc$c12hour)
 values_at(efc$c12hour, "quart2")
+
+mean_sd <- values_at(values = "meansd")
+mean_sd(efc$c12hour)
 
 }

--- a/tests/testthat/test-extract_values.R
+++ b/tests/testthat/test-extract_values.R
@@ -1,0 +1,13 @@
+if (require("testthat") && require("ggeffects")) {
+  test_that("values_at / pretty_range", {
+    x <- 1:1000
+    expect_equal(pretty_range(n = 5)(x),
+                 pretty_range(x, n = 5))
+
+    expect_equal(values_at(values = "meansd")(x),
+                 values_at(x, values = "meansd"))
+
+    expect_equal(values_at(values = "minmax")(x),
+                 values_at(x, values = "minmax"))
+  })
+}


### PR DESCRIPTION
This is really a little thing for me, so I totally get it if you won't accept this (:

The idea is that if `x` is not passed to these functions, then they return a *function* that can be used elsewhere (with the other argument specified)..

This *would* be very convenient to use with `emmeans`'s `cov.reduce` argument - see examples:

``` r

m <- lm(mpg ~ hp * cyl, mtcars)

library(emmeans)
library(ggeffects)

emmeans(m, ~ hp * cyl,
        cov.reduce = list(
          hp = values_at(values = "meansd"),
          cyl = unique
        ))
#>     hp cyl emmean    SE df lower.CL upper.CL
#>   78.1   6   22.0 1.028 28    19.85     24.1
#>  146.7   6   18.4 1.097 28    16.12     20.6
#>  215.3   6   14.8 2.295 28    10.08     19.5
#>   78.1   4   27.1 0.904 28    25.26     29.0
#>  146.7   4   20.8 2.287 28    16.13     25.5
#>  215.3   4   14.5 4.625 28     5.05     24.0
#>   78.1   8   16.8 1.945 28    12.82     20.8
#>  146.7   8   15.9 1.111 28    13.65     18.2
#>  215.3   8   15.0 0.788 28    13.43     16.7
#> 
#> Confidence level used: 0.95

emmeans(m, ~ hp * cyl,
        cov.reduce = list(
          hp = values_at(values = "minmax"),
          cyl = unique
        ))
#>   hp cyl emmean   SE df lower.CL upper.CL
#>   52   6  23.32 1.43 28    20.40     26.2
#>  335   6   8.53 4.66 28    -1.02     18.1
#>   52   4  29.50 1.49 28    26.45     32.6
#>  335   4   3.54 8.82 28   -14.51     21.6
#>   52   8  17.13 2.29 28    12.44     21.8
#>  335   8  13.52 2.05 28     9.33     17.7
#> 
#> Confidence level used: 0.95


emmeans(m, ~ hp * cyl,
        cov.reduce = list(
          hp = pretty_range(length = 3),
          cyl = unique
        ))
#>   hp cyl emmean     SE df lower.CL upper.CL
#>    0   6  26.04  2.379 28    21.16     30.9
#>  100   6  20.81  0.823 28    19.12     22.5
#>  200   6  15.59  2.006 28    11.48     19.7
#>  300   6  10.36  3.962 28     2.24     18.5
#>  400   6   5.13  5.975 28    -7.10     17.4
#>    0   4  34.27  3.177 28    27.77     40.8
#>  100   4  25.10  0.975 28    23.10     27.1
#>  200   4  15.93  4.095 28     7.54     24.3
#>  300   4   6.76  7.586 28    -8.78     22.3
#>  400   4  -2.42 11.104 28   -25.16     20.3
#>    0   8  17.80  3.007 28    11.64     24.0
#>  100   8  16.52  1.661 28    13.12     19.9
#>  200   8  15.24  0.768 28    13.67     16.8
#>  300   8  13.96  1.592 28    10.70     17.2
#>  400   8  12.69  2.931 28     6.68     18.7
#> 
#> Confidence level used: 0.95
```

<sup>Created on 2020-12-20 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

This can be done with `purrr`:

``` r
library(purrr)

emmeans(m, ~ hp * cyl,
        cov.reduce = list(
          hp = partial(values_at, values = "meansd"),
          cyl = unique
        ))
#>     hp cyl emmean    SE df lower.CL upper.CL
#>   78.1   6   22.0 1.028 28    19.85     24.1
#>  146.7   6   18.4 1.097 28    16.12     20.6
#>  215.3   6   14.8 2.295 28    10.08     19.5
#>   78.1   4   27.1 0.904 28    25.26     29.0
#>  146.7   4   20.8 2.287 28    16.13     25.5
#>  215.3   4   14.5 4.625 28     5.05     24.0
#>   78.1   8   16.8 1.945 28    12.82     20.8
#>  146.7   8   15.9 1.111 28    13.65     18.2
#>  215.3   8   15.0 0.788 28    13.43     16.7
#> 
#> Confidence level used: 0.95
```

but would be nice to have this baked in...