### PR TITLE
fix residual type to "working" + make types in glm/lmm more explicit in docs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # ggeffects 1.0.1.001
 
+## Breaking changes
+
+* `residuals.type` argument in `plot()` is deprecated. Always using `"working"` residuals.
+
 ## General
 
 * `pretty_range()` and `values_at()` can now also be used as function factories.

--- a/R/plot.R
+++ b/R/plot.R
@@ -21,9 +21,6 @@
 #' @param residuals Logical, if \code{TRUE}, a layer with partial residuals is
 #'   added to the plot. See vignette \href{https://cran.r-project.org/package=effects}{"Effect Displays with Partial Residuals"}
 #'   from \pkg{effects} for more details on partial residual plots.
-#' @param residuals.type The type of residuals to be plotted. Only applies if \code{residuals}
-#'   is \code{TRUE}. See \code{\link[stats:residuals.glm]{residuals.glm()}} for
-#'   details.
 #' @param residuals.line Logical, if \code{TRUE}, a loess-fit line is added to the
 #'   partial residuals plot. Only applies if \code{residuals} is \code{TRUE}.
 #' @param colors Character vector with color values in hex-format, valid
@@ -71,8 +68,11 @@
 #' @param base_family Base font family.
 #' @param ... Further arguments passed down to \code{ggplot::scale_y*()}, to
 #'    control the appearance of the y-axis.
+#' @param residuals.type Deprecated. Formally was the residual type. Now is always \code{"working"}.
 #'
 #' @inheritParams get_title
+#'
+#' @inheritSection residualize_over_grid Partial Residuals
 #'
 #' @return A ggplot2-object.
 #'
@@ -127,7 +127,6 @@ plot.ggeffects <- function(x,
                            facets,
                            add.data = FALSE,
                            residuals = FALSE,
-                           residuals.type = NULL,
                            residuals.line = FALSE,
                            colors = "Set1",
                            alpha = .15,
@@ -147,11 +146,14 @@ plot.ggeffects <- function(x,
                            grid,
                            one.plot = TRUE,
                            rawdata,
+                           residuals.type,
                            ...) {
 
   if (!requireNamespace("ggplot2", quietly = FALSE)) {
     stop("Package `ggplot2` needed to produce marginal effects plots. Please install it by typing `install.packages(\"ggplot2\", dependencies = TRUE)` into the console.", call. = FALSE)
   }
+
+  if (!residuals.type) warning("'residuals.type' is deprecated. Using 'working' residuals.")
 
   # check alias
   if (missing(rawdata)) rawdata <- add.data
@@ -229,7 +231,7 @@ plot.ggeffects <- function(x,
     }
 
     if (!is.null(model)) {
-      residual_data <- residualize_over_grid(grid = x, model = model, type = residuals.type)
+      residual_data <- residualize_over_grid(grid = x, model = model)
       attr(x, "residual_data") <- residual_data
 
       ## TODO for now, we allow no continuous grouping varialbles for partial residuals

--- a/R/plot.R
+++ b/R/plot.R
@@ -153,7 +153,7 @@ plot.ggeffects <- function(x,
     stop("Package `ggplot2` needed to produce marginal effects plots. Please install it by typing `install.packages(\"ggplot2\", dependencies = TRUE)` into the console.", call. = FALSE)
   }
 
-  if (!residuals.type) warning("'residuals.type' is deprecated. Using 'working' residuals.")
+  if (!missing(residuals.type)) warning("'residuals.type' is deprecated. Using 'working' residuals.")
 
   # check alias
   if (missing(rawdata)) rawdata <- add.data

--- a/R/residualize_over_grid.R
+++ b/R/residualize_over_grid.R
@@ -52,7 +52,7 @@ residualize_over_grid <- function(grid, model, ...) {
 #' @export
 residualize_over_grid.data.frame <- function(grid, model, pred_name, type, ...) {
 
-  if (!type) warning("'residuals.type' is deprecated. Using 'working' residuals.")
+  if (!missing(type)) warning("'residuals.type' is deprecated. Using 'working' residuals.")
 
   old_d <- insight::get_predictors(model)
   fun_link <- insight::link_function(model)

--- a/man/plot.Rd
+++ b/man/plot.Rd
@@ -14,7 +14,6 @@
   facets,
   add.data = FALSE,
   residuals = FALSE,
-  residuals.type = NULL,
   residuals.line = FALSE,
   colors = "Set1",
   alpha = 0.15,
@@ -34,6 +33,7 @@
   grid,
   one.plot = TRUE,
   rawdata,
+  residuals.type,
   ...
 )
 
@@ -65,10 +65,6 @@ predictor on the x-axis, plotted as point-geoms, is added to the plot.}
 \item{residuals}{Logical, if \code{TRUE}, a layer with partial residuals is
 added to the plot. See vignette \href{https://cran.r-project.org/package=effects}{"Effect Displays with Partial Residuals"}
 from \pkg{effects} for more details on partial residual plots.}
-
-\item{residuals.type}{The type of residuals to be plotted. Only applies if \code{residuals}
-is \code{TRUE}. See \code{\link[stats:residuals.glm]{residuals.glm()}} for
-details.}
 
 \item{residuals.line}{Logical, if \code{TRUE}, a loess-fit line is added to the
 partial residuals plot. Only applies if \code{residuals} is \code{TRUE}.}
@@ -133,6 +129,8 @@ of same groups will be connected with a line.}
 \item{one.plot}{Logical, if \code{TRUE} and \code{x} has a \code{panel} column
 (i.e. when four \code{terms} were used), a single, integrated plot is produced.}
 
+\item{residuals.type}{Deprecated. Formally was the residual type. Now is always \code{"working"}.}
+
 \item{...}{Further arguments passed down to \code{ggplot::scale_y*()}, to
 control the appearance of the y-axis.}
 
@@ -161,6 +159,16 @@ Load \code{library(ggplot2)} and use \code{theme_set(theme_ggeffects())}
   There are pre-defined colour palettes in this package. Use
   \code{show_pals()} to show all available colour palettes.
 }
+\section{Partial Residuals}{
+
+For \strong{generalized linear models} (glms), residualized scores are
+computed as \code{inv.link(link(Y) + r)} where \code{Y} are the predicted
+values on the response scale, and \code{r} are the \emph{working} residuals.
+\cr\cr
+For (generalized) linear \strong{mixed models}, the random effect are also
+partialled out.
+}
+
 \examples{
 library(sjlabelled)
 data(efc)

--- a/man/residualize_over_grid.Rd
+++ b/man/residualize_over_grid.Rd
@@ -8,9 +8,9 @@
 \usage{
 residualize_over_grid(grid, model, ...)
 
-\method{residualize_over_grid}{data.frame}(grid, model, pred_name, type = NULL, ...)
+\method{residualize_over_grid}{data.frame}(grid, model, pred_name, type, ...)
 
-\method{residualize_over_grid}{ggeffects}(grid, model, protect_names = TRUE, type = NULL, ...)
+\method{residualize_over_grid}{ggeffects}(grid, model, protect_names = TRUE, ...)
 }
 \arguments{
 \item{grid}{A data frame representing the data grid, or an object of class \code{ggeffects}, as returned by \code{ggpredict()} and others.}
@@ -21,7 +21,7 @@ residualize_over_grid(grid, model, ...)
 
 \item{pred_name}{The name of the focal predictor, for which partial residuals are computed.}
 
-\item{type}{Type of residuals. Passed down to \code{stats::residuals()}.}
+\item{type}{Deprecated. Formally was the residual type. Now is always \code{"working"}.}
 
 \item{protect_names}{Logical, if \code{TRUE}, preserves column names from the \code{ggeffects} objects that is used as \code{grid}.}
 }
@@ -35,6 +35,16 @@ This function computes partial residuals based on a data grid,
   as \code{newdata} argument in \code{predict()}, and can be created with
   \code{\link{new_data}}.
 }
+\section{Partial Residuals}{
+
+For \strong{generalized linear models} (glms), residualized scores are
+computed as \code{inv.link(link(Y) + r)} where \code{Y} are the predicted
+values on the response scale, and \code{r} are the \emph{working} residuals.
+\cr\cr
+For (generalized) linear \strong{mixed models}, the random effect are also
+partialled out.
+}
+
 \examples{
 library(ggeffects)
 set.seed(1234)


### PR DESCRIPTION
@strengejacke This PR 

1. removes the `residuals.type` argument, fixing this to `type = "working"`.
This is following a deeper dive into the `effects`code, and some reading.
Also documented this in the docs.

2. Made it clear in the docs that for mixed models, the random effect are also partialled out.
Note that this is not what `effects` does, but I think that as long as this is documented, this should be okay.
(The code in `effects` essentially refits a model with only the fixed effects, so not sure if this is just a side effect of this, or if this is intentional).