### PR TITLE
fix collapse.group with factor binomial response

### DIFF
--- a/R/collapse_re_data.R
+++ b/R/collapse_re_data.R
@@ -65,6 +65,13 @@ collapse_by_group <- function(grid, model, collapse.by = NULL, residuals = FALSE
     }
   }
 
+  if (is.factor(rawdata[[y_name]])) {
+    rawdata[[y_name]] <- as.numeric(rawdata[[y_name]])
+    if (insight::model_info(model)$is_binomial) {
+      rawdata[[y_name]] <- rawdata[[y_name]] - 1
+    } # else ordinal?
+  }
+
   rawdata$random <- factor(data[[collapse.by]])
 
   agg_data <- stats::aggregate(rawdata[[y_name]],


### PR DESCRIPTION
Fixed

``` r
d <- tibble::tribble(
  ~subId,  ~Condition, ~ProbeNum, ~ImageNum,        ~Answer,
  "118",  "Original",   "first",  "15.jpg", "Unrecognized",
  "103",  "Original",  "second",  "41.jpg",   "Recognized",
  "111",  "Original",   "first",  "32.jpg", "Unrecognized",
  "117", "Scrambled",   "first",  "26.jpg", "Unrecognized",
  "117",  "Original",  "second",  "31.jpg",   "Recognized",
  "101",  "Original",  "second",   "2.jpg",   "Recognized",
  "117",  "Original",  "second",   "1.jpg", "Unrecognized",
  "120", "Scrambled",   "first",  "12.jpg", "Unrecognized",
  "112", "Scrambled",  "second",  "28.jpg", "Unrecognized",
  "108",  "Original",   "first",  "29.jpg",   "Recognized"
)

d$Answer <- factor(d$Answer)

m <- lme4::glmer(Answer ~ Condition * ProbeNum + (1|subId) + (1|ImageNum),
                 family = binomial(),
                 data = d)
#> boundary (singular) fit: see help('isSingular')

ggeffects::ggemmeans(m, c("ProbeNum")) |>
  plot(add.data = TRUE, collapse.group = "subId", jitter = c(0.1, 0)) 
#> Loading required namespace: emmeans
#> NOTE: Results may be misleading due to involvement in interactions
#> Loading required namespace: ggplot2
```

![](https://i.imgur.com/zCxqHir.png)

<sup>Created on 2022-02-07 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>


## New error

When `residuals = TRUE`. @strengejacke If you can find where this is happening, I can try and fix it too.

``` r
ggeffects::ggemmeans(m, c("ProbeNum")) |>
  plot(residuals = TRUE, collapse.group = "subId") 
#> Loading required namespace: emmeans
#> NOTE: Results may be misleading due to involvement in interactions
#> Loading required namespace: ggplot2
#> Error in FUN(X[[i]], ...): object 'group_col' not found
```