### PR TITLE
Changed logistf test

### DIFF
--- a/tests/testthat/test-logistf.R
+++ b/tests/testthat/test-logistf.R
@@ -17,6 +17,7 @@ if (suppressWarnings(
   })
 
   test_that("ggemmeans, logistf", {
-    expect_null(ggemmeans(m1, "age"))
+      pr <- ggemmeans(m1, "age")
+      expect_equal(pr$predicted[1], 0.5660724, tolerance = 1e-3)
   })
 }

--- a/tests/testthat/test-logistf.R
+++ b/tests/testthat/test-logistf.R
@@ -17,7 +17,8 @@ if (suppressWarnings(
   })
 
   test_that("ggemmeans, logistf", {
-      pr <- ggemmeans(m1, "age")
-      expect_equal(pr$predicted[1], 0.5660724, tolerance = 1e-3)
+    testthat::skip_if_not_installed("logistf", minimum_version = "1.25.0")
+    pr <- ggemmeans(m1, "age")
+    expect_equal(pr$predicted[1], 0.5660724, tolerance = 1e-3)
   })
 }


### PR DESCRIPTION
Hello,

we recently added support for `emmeans` to the `logistf` package (https://github.com/georgheinze/logistf/issues/51). However, upon submitting the newest version to CRAN, we were informed that this change causes problems in your package.

Based on my understanding, the `ggemmeans()` did not work with `logistf` objects prior to this change, but it will work with the newest version. This will cause the last test in your test-logistf.R to fail. I simply changed the last test such that they now all pass with the updated version of `logistf`.