### PR TITLE
add SE to nestedLogit

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: ggeffects
 Type: Package
 Encoding: UTF-8
 Title: Create Tidy Data Frames of Marginal Effects for 'ggplot' from Model Outputs
-Version: 1.2.2.12
+Version: 1.2.2.13
 Authors@R: c(
       person("Daniel", "Lüdecke", role = c("aut", "cre"), email = "d.luedecke@uke.de", comment = c(ORCID = "0000-0002-8895-3206")),
       person("Frederik", "Aust", role = "ctb", comment = c(ORCID = "0000-0003-4900-788X")),
@@ -60,7 +60,7 @@ Suggests:
     mice,
     MCMCglmm,
     mgcv,
-    nestedLogit,
+    nestedLogit (>= 0.3.0),
     nlme,
     ordinal,
     parameters,

--- a/R/get_predictions_nestedLogit.R
+++ b/R/get_predictions_nestedLogit.R
@@ -10,31 +10,20 @@ get_predictions_nestedLogit <- function(model, data_grid, ci.lvl, linv, ...) {
     model,
     newdata = data_grid,
     ...
-  ))
-
-  # create ID for merging
-  data_grid$.rowid <- seq_len(nrow(data_grid))
-  predictions$.rowid <- data_grid$.rowid
+  ), newdata = data_grid)
 
   colnames(predictions)[colnames(predictions) == "response"] <- "response.level"
   colnames(predictions)[colnames(predictions) == "logit"] <- "predicted"
 
-  # merge predictions to data grid
-  data_grid <- merge(
-    predictions[c("response.level", "predicted", "se.logit", ".rowid")],
-    data_grid,
-    by = ".rowid",
-    sort = FALSE
-  )
-
   # CI
-  data_grid$conf.low <- linv(data_grid$predicted - stats::qnorm(ci) * data_grid$se.logit)
-  data_grid$conf.high <- linv(data_grid$predicted + stats::qnorm(ci) * data_grid$se.logit)
-  data_grid$predicted <- linv(data_grid$predicted)
+  predictions$conf.low <- linv(predictions$predicted - stats::qnorm(ci) * predictions$se.logit)
+  predictions$conf.high <- linv(predictions$predicted + stats::qnorm(ci) * predictions$se.logit)
+  predictions$predicted <- linv(predictions$predicted)
 
   # remove SE
-  data_grid$se.logit <- NULL
-  data_grid$.rowid <- NULL
+  predictions$se.logit <- NULL
+  predictions$se.p <- NULL
+  predictions[["p"]] <- NULL
 
-  data_grid
+  predictions
 }

--- a/R/get_predictions_nestedLogit.R
+++ b/R/get_predictions_nestedLogit.R
@@ -6,19 +6,25 @@ get_predictions_nestedLogit <- function(model, fitfram, ci.lvl, ...) {
     ci <- 0.975
 
 
-  prdat <- as.data.frame(stats::predict(
+  predictions <- as.data.frame(stats::predict(
     model,
     newdata = fitfram,
     ...
   ))
 
-  nc <- seq_len(ncol(prdat))
+  nr <- nrow(predictions)
+  
   tmp <- cbind(prdat, fitfram)
-  fitfram <- .gather(tmp, names_to = "response.level", values_to = "predicted", colnames(tmp)[nc])
+  fitfram_pred <- .gather(tmp, names_to = "response.level", values_to = "predicted", colnames(tmp)[nc])
 
-  # No CI
-  fitfram$conf.low <- NA
-  fitfram$conf.high <- NA
+  # standard errors
+  se <- predictions[["se.p"]]
+  tmp <- cbind(se, fitfram)
+  fitfram_se <- .gather(tmp, names_to = "response.level", values_to = "predicted", colnames(tmp)[nc])
+
+  # CI
+  fitfram$conf.low <- linv(stats::qlogis(fitfram$predicted) - stats::qnorm(ci) * se.fit)
+  fitfram$conf.high <- linv(stats::qlogis(fitfram$predicted) + stats::qnorm(ci) * se.fit)
 
   fitfram
 }

--- a/R/predictions.R
+++ b/R/predictions.R
@@ -36,7 +36,7 @@ select_prediction_method <- function(model_class,
   } else if (model_class == "logitr") {
     prediction_data <- get_predictions_logitr(model, data_grid, ci.lvl, ...)
   } else if (model_class == "nestedLogit") {
-    prediction_data <- get_predictions_nestedLogit(model, data_grid, ci.lvl, ...)
+    prediction_data <- get_predictions_nestedLogit(model, data_grid, ci.lvl, linv, ...)
   } else if (model_class %in% c("lrm", "orm")) {
     prediction_data <- get_predictions_lrm(model, data_grid, ci.lvl, linv, ...)
   } else if (model_class == "glimML") {

--- a/tests/testthat/test-nestedLogit.R
+++ b/tests/testthat/test-nestedLogit.R
@@ -27,6 +27,7 @@ if (requiet("testthat") &&
 
     out <- as.data.frame(ggpredict(m, c("hincome [30, 40]", "children")))
     expected <- as.data.frame(predict(m, newdata = new), newdata = new)
+    expected <- expected[order(expected$hincome, expected$children), ]
 
     expect_equal(
       out$predicted,

--- a/tests/testthat/test-nestedLogit.R
+++ b/tests/testthat/test-nestedLogit.R
@@ -26,11 +26,7 @@ if (requiet("testthat") &&
     )
 
     out <- as.data.frame(ggpredict(m, c("hincome [30, 40]", "children")))
-    out <- out[out$response.level == "fulltime", ]
-
-    expected <- cbind(new, as.data.frame(predict(m, newdata = new)))
-    expected <- expected[expected$response == "fulltime", ]
-    expected <- expected[order(expected$hincom, expected$children), ]
+    expected <- as.data.frame(predict(m, newdata = new), newdata = new)
 
     expect_equal(
       out$predicted,
@@ -41,7 +37,9 @@ if (requiet("testthat") &&
 
     expect_equal(
       out$conf.low,
-      c(0.0034, 0.13574, 0.02488, 0.00037),
+      c(
+        0.30665, 0.09012, 0.13574, 0.6929, 0.08997, 0.0034, 0.32716, 
+        0.10429, 0.02488, 0.70621, 0.0465, 0.00037),
       ignore_attr = TRUE,
       tolerance = 1e-3
     )

--- a/tests/testthat/test-nestedLogit.R
+++ b/tests/testthat/test-nestedLogit.R
@@ -21,16 +21,27 @@ if (requiet("testthat") &&
     )
 
     new <- expand.grid(
-      hincome = seq(0, 45, by = 5),
+      hincome = c(30, 40),
       children = c("absent", "present")
     )
-    out <- ggpredict(m, c("hincome [0:45 by=5]", "children"))
+
+    out <- as.data.frame(ggpredict(m, c("hincome [30, 40]", "children")))
     out <- out[out$response.level == "fulltime", ]
-    out <- out[order(out$group, out$x), ]
+
+    expected <- cbind(new, as.data.frame(predict(m, newdata = new)))
+    expected <- expected[expected$response == "fulltime", ]
+    expected <- expected[order(expected$hincom, expected$children), ]
 
     expect_equal(
       out$predicted,
-      unname(predict(m, newdata = new)[, "fulltime"]),
+      expected$p,
+      ignore_attr = TRUE,
+      tolerance = 1e-3
+    )
+
+    expect_equal(
+      out$conf.low,
+      c(0.0034, 0.13574, 0.02488, 0.00037),
       ignore_attr = TRUE,
       tolerance = 1e-3
     )


### PR DESCRIPTION
``` r
library(ggeffects)
library(nestedLogit)
data(Womenlf, package = "carData")
Womenlf$partic <- with(
  Womenlf,
  factor(partic, levels = c("not.work", "parttime", "fulltime"))
)

m <- nestedLogit::nestedLogit(partic ~ hincome + children,
  dichotomies = nestedLogit::logits(
    work = nestedLogit::dichotomy("not.work", working = c("parttime", "fulltime")),
    full = nestedLogit::dichotomy("parttime", "fulltime")
  ),
  data = Womenlf
)

new <- expand.grid(
  hincome = c(30, 40),
  children = c("absent", "present")
)

ggpredict(m, c("hincome [30, 40]", "children"))
#> # Predicted probabilities of partic
#> 
#> # Response Level = not.work
#> # children = absent
#> 
#> hincome | Predicted |       95% CI
#> ----------------------------------
#>      30 |      0.48 | [0.31, 0.66]
#>      40 |      0.59 | [0.33, 0.81]
#> 
#> # Response Level = parttime
#> # children = absent
#> 
#> hincome | Predicted |       95% CI
#> ----------------------------------
#>      30 |      0.22 | [0.09, 0.46]
#>      40 |      0.29 | [0.10, 0.58]
#> 
#> # Response Level = fulltime
#> # children = absent
#> 
#> hincome | Predicted |       95% CI
#> ----------------------------------
#>      30 |      0.29 | [0.14, 0.52]
#>      40 |      0.13 | [0.02, 0.45]
#> 
#> # Response Level = not.work
#> # children = present
#> 
#> hincome | Predicted |       95% CI
#> ----------------------------------
#>      30 |      0.82 | [0.69, 0.90]
#>      40 |      0.87 | [0.71, 0.95]
#> 
#> # Response Level = parttime
#> # children = present
#> 
#> hincome | Predicted |       95% CI
#> ----------------------------------
#>      30 |      0.17 | [0.09, 0.29]
#>      40 |      0.12 | [0.05, 0.29]
#> 
#> # Response Level = fulltime
#> # children = present
#> 
#> hincome | Predicted |       95% CI
#> ----------------------------------
#>      30 |      0.02 | [0.00, 0.07]
#>      40 |      0.00 | [0.00, 0.04]

as.data.frame(predict(m, newdata = new), newdata = new)
#>    hincome children response           p        se.p       logit  se.logit
#> 1       30   absent not.work 0.483361927 0.095465380 -0.06657687 0.3822848
#> 2       30   absent parttime 0.224958781 0.095638728 -1.23699902 0.5485371
#> 3       30   absent fulltime 0.291679292 0.101605781 -0.88724209 0.4917936
#> 4       40   absent not.work 0.588194721 0.133170256  0.35650744 0.5497867
#> 5       40   absent parttime 0.285272275 0.128164048 -0.91845759 0.6285879
#> 6       40   absent fulltime 0.126533004 0.097928271 -1.93196717 0.8860491
#> 7       30  present not.work 0.818923571 0.052610678  1.50907156 0.3547877
#> 8       30  present parttime 0.165901061 0.049355986 -1.61496044 0.3566754
#> 9       30  present fulltime 0.015175368 0.011491854 -4.17278999 0.7689391
#> 10      40  present not.work 0.873487849 0.059489224  1.93215586 0.5383308
#> 11      40  present parttime 0.122673467 0.057838540 -1.96735317 0.5374096
#> 12      40  present fulltime 0.003838684 0.004592451 -5.55877971 1.2009709
```

<sup>Created on 2023-06-01 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>
