### PR TITLE
Add sdmTMB compatibility

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,7 +7,8 @@ Authors@R: c(
       person("Daniel", "Lüdecke", role = c("aut", "cre"), email = "d.luedecke@uke.de", comment = c(ORCID = "0000-0002-8895-3206")),
       person("Frederik", "Aust", role = "ctb", comment = c(ORCID = "0000-0003-4900-788X")),
       person("Sam", "Crawley", role = "ctb", email = "sam@crawley.nz", comment = c(ORCID = "0000-0002-7847-0411")),
-	    person("Mattan S.", "Ben-Shachar", role = c("ctb"), email = "matanshm@post.bgu.ac.il", comment = c(ORCID = "0000-0002-4287-4801"))
+      person(c("Mattan", "S."), "Ben-Shachar", role = "ctb", email = "matanshm@post.bgu.ac.il", comment = c(ORCID = "0000-0002-4287-4801")),
+      person(c("Sean", "C."), "Anderson", role = "ctb", email = "sean@seananderson.ca", comment = c(ORCID = "0000-0001-9563-1937"))
     )
 Maintainer: Daniel Lüdecke <d.luedecke@uke.de>
 Description: Compute marginal effects and adjusted predictions from statistical

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: ggeffects
 Type: Package
 Encoding: UTF-8
 Title: Create Tidy Data Frames of Marginal Effects for 'ggplot' from Model Outputs
-Version: 1.3.2
+Version: 1.3.2.1
 Authors@R: c(
       person("Daniel", "Lüdecke", role = c("aut", "cre"), email = "d.luedecke@uke.de", comment = c(ORCID = "0000-0002-8895-3206")),
       person("Frederik", "Aust", role = "ctb", comment = c(ORCID = "0000-0003-4900-788X")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -75,6 +75,7 @@ Suggests:
     rstanarm,
     rstantools,
     sandwich,
+    sdmTMB (>= 0.4.0),
     see,
     sjlabelled (>= 1.1.2),
     sjstats,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# ggeffects 1.3.2.1
+
+## General
+
+* Support for `sdmTMB` (*sdmTMB*) models.
+
 # ggeffects 1.3.2
 
 ## Breaking changes

--- a/R/get_predictions_sdmTMB.R
+++ b/R/get_predictions_sdmTMB.R
@@ -9,7 +9,7 @@ get_predictions_sdmTMB <- function(model, data_grid, ci.lvl, linv, type, ...) {
   # copy object
   predicted_data <- data_grid
 
-  if (!type %in% "fe") {
+  if (type != "fe") {
     insight::format_error("Only `type = 'fe'` is currently supported for sdmTMB models.")
   }
 

--- a/R/get_predictions_sdmTMB.R
+++ b/R/get_predictions_sdmTMB.R
@@ -1,0 +1,38 @@
+get_predictions_sdmTMB <- function(model, data_grid, ci.lvl, linv, type, ...) {
+
+  # does user want standard errors?
+  se <- !is.null(ci.lvl) && !is.na(ci.lvl)
+
+  # compute ci
+  if (se) ci <- (1 + ci.lvl) / 2
+
+  # copy object
+  predicted_data <- data_grid
+
+  if (!type %in% "fe") {
+    insight::format_error("Only `type = 'fe'` is currently supported for sdmTMB models.")
+  }
+
+  # predict
+  prdat <- stats::predict(
+    model,
+    newdata = data_grid,
+    se_fit = se,
+    re_form = NA, # i.e., spatial/spatiotemporal random fields off
+    re_form_iid = NA,
+    ...
+  )
+
+  # form output data frame
+  predicted_data$predicted <- linv(prdat$est)
+  if (se) {
+    predicted_data$conf.low <- linv(prdat$est - stats::qnorm(ci) * prdat$est_se)
+    predicted_data$conf.high <- linv(prdat$est + stats::qnorm(ci) * prdat$est_se)
+    predicted_data$std.error <- prdat$est_se
+  } else {
+    predicted_data$conf.low <- NA
+    predicted_data$conf.high <- NA
+    predicted_data$std.error <- NA
+  }
+  predicted_data
+}

--- a/R/ggpredict.R
+++ b/R/ggpredict.R
@@ -580,6 +580,9 @@ ggpredict <- function(model,
   # extract just the mer-part then
   if (is.gamm(model) || is.gamm4(model)) model <- model$gam
 
+  # for sdmTMB objects, delta/hurdle models have family lists
+  if (.is_delta_sdmTMB(model)) insight::format_error("ggpredict() does not yet work with sdmTMB delta models.")
+
   if (inherits(model, "list") && !inherits(model, c("bamlss", "maxLik"))) {
     res <- lapply(model, function(.x) {
       ggpredict_helper(

--- a/R/predictions.R
+++ b/R/predictions.R
@@ -43,6 +43,8 @@ select_prediction_method <- function(model_class,
     prediction_data <- get_predictions_glimML(model, data_grid, ci.lvl, linv, ...)
   } else if (model_class == "glmmTMB") {
     prediction_data <- get_predictions_glmmTMB(model, data_grid, ci.lvl, linv, type, terms, value_adjustment, condition, interval, verbose = verbose, ...)
+  } else if (model_class == "sdmTMB") {
+    prediction_data <- get_predictions_sdmTMB(model, data_grid, ci.lvl, linv, type, ...)
   } else if (model_class == "wbm") {
     prediction_data <- get_predictions_wbm(model, data_grid, ci.lvl, linv, type, terms, condition, ...)
   } else if (model_class %in% c("lmer", "nlmer", "glmer")) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -274,6 +274,17 @@ is.gamm4 <- function(x) {
 }
 
 
+.is_delta_sdmTMB <- function(x) {
+  ret <- FALSE
+  if (inherits(x, "sdmTMB")) {
+    if (isTRUE(x$family$delta)) {
+      ret <- TRUE
+    }
+  }
+  ret
+}
+
+
 .n_distinct <- function(x, na.rm = TRUE) {
   if (na.rm) x <- x[!is.na(x)]
   length(unique(x))

--- a/R/utils_model_function.R
+++ b/R/utils_model_function.R
@@ -61,6 +61,7 @@ get_predict_function <- function(model) {
   else if (inherits(model, "Gam")) return("Gam")
   else if (inherits(model, "MCMCglmm")) return("MCMCglmm")
   else if (inherits(model, "glmerMod")) return("glmer")
+  else if (inherits(model, "sdmTMB")) return("sdmTMB")
   else if (inherits(model, "glmmTMB")) return("glmmTMB")
   else if (inherits(model, "nlmerMod")) return("nlmer")
   else if (inherits(model, c("lmerMod", "merModLmerTest", "rlmerMod"))) return("lmer")

--- a/tests/testthat/test-sdmTMB.R
+++ b/tests/testthat/test-sdmTMB.R
@@ -1,0 +1,90 @@
+.runThisTest <- Sys.getenv("RunAllggeffectsTests") == "yes"
+
+if (.runThisTest && getRversion() >= "4.0.0" && requiet("testthat") && requiet("ggeffects") && requiet("sdmTMB") && requiet("glmmTMB") && requiet("mgcv")) {
+  test_that("ggpredict for sdmTMB without random fields validates against glm()", {
+    pcod_2011$fyear <- as.factor(pcod_2011$year)
+    fit <- sdmTMB(
+      present ~ poly(depth_scaled, 2) + fyear,
+      data = pcod_2011,
+      spatial = "off",
+      family = binomial()
+    )
+    p <- ggpredict(fit, "depth_scaled [all]")
+
+    fit_glm <- glm(
+      present ~ poly(depth_scaled, 2) + fyear,
+      data = pcod_2011,
+      family = binomial()
+    )
+    p_glm <- ggpredict(fit_glm, "depth_scaled [all]")
+
+    expect_equal(p$predicted, p_glm$predicted, tolerance = 1e-4)
+    expect_equal(p$std.error, p_glm$std.error, tolerance = 1e-4)
+    expect_equal(p$conf.low, p_glm$conf.low, tolerance = 1e-4)
+    expect_equal(p$conf.high, p_glm$conf.high, tolerance = 1e-4)
+
+    p <- ggpredict(fit, "depth_scaled [all]", back_transform = FALSE)
+    p_glm <- ggpredict(fit_glm, "depth_scaled [all]", back_transform = FALSE)
+    expect_equal(p$predicted, p_glm$predicted, tolerance = 1e-4)
+    expect_equal(p$std.error, p_glm$std.error, tolerance = 1e-4)
+    expect_equal(p$conf.low, p_glm$conf.low, tolerance = 1e-4)
+    expect_equal(p$conf.high, p_glm$conf.high, tolerance = 1e-4)
+  })
+
+  test_that("ggpredict for sdmTMB *with* random fields returns sensible values", {
+    mesh <- make_mesh(pcod_2011, c("X", "Y"), cutoff = 15)
+    fit <- sdmTMB(
+      present ~ poly(depth_scaled, 2),
+      data = pcod_2011,
+      spatial = "on",
+      mesh = mesh,
+      family = binomial()
+    )
+    p <- ggpredict(fit, "depth_scaled [all]")
+    expect_true(sum(is.na(p$std.error)) == 0L)
+    expect_error(ggpredict(fit, "depth_scaled [all]", type = "re"), regexp = "supported")
+  })
+
+  test_that("ggpredict for sdmTMB delta models returns an error for now", {
+    fit <- sdmTMB(
+      density ~ depth_scaled,
+      data = pcod_2011,
+      spatial = "off",
+      family = delta_gamma()
+    )
+    expect_error(ggpredict(fit, "depth_scaled [all]"), regexp = "delta")
+  })
+
+  test_that("ggpredict for sdmTMB with IID random intercepts matches glmmTMB", {
+    pcod_2011$fyear <- as.factor(pcod_2011$year)
+    fit <- sdmTMB(
+      present ~ depth_scaled + (1 | fyear),
+      data = pcod_2011,
+      spatial = "off",
+      family = binomial()
+    )
+    p <- ggpredict(fit, "depth_scaled [all]")
+
+    fit_glm <- glmmTMB::glmmTMB(
+      present ~ depth_scaled + (1 | fyear),
+      data = pcod_2011,
+      family = binomial()
+    )
+    p_glm <- ggpredict(fit_glm, "depth_scaled [all]")
+
+    expect_equal(p$predicted, p_glm$predicted, tolerance = 1e-4)
+    expect_equal(p$std.error, p_glm$std.error, tolerance = 1e-4)
+    expect_equal(p$conf.low, p_glm$conf.low, tolerance = 1e-4)
+    expect_equal(p$conf.high, p_glm$conf.high, tolerance = 1e-4)
+  })
+
+  test_that("ggpredict for sdmTMB works with smoothers and matches mgcv", {
+    set.seed(1)
+    invisible(capture.output(dat <- mgcv::gamSim(3, n = 800)))
+    fit_gam <- mgcv::gam(y ~ s(x2, by = x1), data = dat)
+    fit <- sdmTMB(y ~ s(x2, by = x1), data = dat, spatial = "off")
+    p <- ggpredict(fit, "x2 [all]")
+    p_gam <- ggpredict(fit_gam, "x2 [all]")
+    expect_equal(p$predicted, as.numeric(p_gam$predicted), tolerance = 1e-2)
+  })
+}


### PR DESCRIPTION
Adds support for the [sdmTMB](https://cran.r-project.org/package=sdmTMB) package to `ggpredict()`. `ggeffect()` and `ggemmeans()` already work without any modifications to ggeffects. Make sure to install sdmTMB 0.4.0 (on CRAN as of today). Prior versions of sdmTMB will technically work too, but prior versions required [INLA](https://www.r-inla.org/), which may trigger notes/warnings with R CMD checks and unit testing with ggeffects since INLA is not on CRAN.

sdmTMB supports delta/hurdle models where a Bernoulli distribution is used for 0s vs. 1s and a positive distribution is used for positive values. Internally these are handled as lists of families. For now, these will not work with `ggpredict()` and an appropriate error is issued.