### PR TITLE
modify ggpredict behaviour for multivariate vglm

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: ggeffects
 Type: Package
 Encoding: UTF-8
 Title: Create Tidy Data Frames of Marginal Effects for 'ggplot' from Model Outputs
-Version: 1.3.4.3
+Version: 1.3.4.4
 Authors@R: c(
       person("Daniel", "Lüdecke", role = c("aut", "cre"), email = "d.luedecke@uke.de", comment = c(ORCID = "0000-0002-8895-3206")),
       person("Frederik", "Aust", role = "ctb", comment = c(ORCID = "0000-0003-4900-788X")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,11 @@
 * `print_html()`, to print the output as HTML table. This method is available
   for objects from `ggpredict()` (and alike) as well as `hypothesis_test()`.
 
+## Bug fixes
+
+* Fixed issue with `ggpredict()` for models of class `vglm` with multivariate
+  responses.
+
 # ggeffects 1.3.4
 
 ## General

--- a/R/get_predictions_vglm.R
+++ b/R/get_predictions_vglm.R
@@ -28,7 +28,8 @@ get_predictions_vglm <- function(model, fitfram, ci.lvl, linv, ...) {
     ...
   )
 
-  if (mi$is_ordinal || mi$is_multinomial) {
+  if (mi$is_ordinal || mi$is_multinomial ||
+      model@extra$multiple.responses == TRUE) {
     # start here with cumulative link models
     resp <- insight::get_response(model)
 
@@ -39,7 +40,9 @@ get_predictions_vglm <- function(model, fitfram, ci.lvl, linv, ...) {
 
     if (se) {
       dat <- data.frame(predicted = prdat$fitted.values)
-      resp.names <- resp.names[-1]
+      if(model@extra$multiple.responses != TRUE) {
+        resp.names <- resp.names[-1]
+      }
     } else {
       dat <- data.frame(predicted = prdat)
       linv <- function(mu) mu

--- a/R/get_predictions_vglm.R
+++ b/R/get_predictions_vglm.R
@@ -4,10 +4,7 @@ get_predictions_vglm <- function(model, fitfram, ci.lvl, linv, ...) {
   se <- !is.null(ci.lvl) && !is.na(ci.lvl)
   mi <- insight::model_info(model)
 
-  is_multivariate <- model@extra$multiple.responses
-  if(is.null(is_multivariate)) {
-    is_multivariate <- FALSE
-  }
+  is_multivariate <- isTRUE(model@extra$multiple.responses)
 
   # compute ci, two-ways
   if (!is.null(ci.lvl) && !is.na(ci.lvl))

--- a/R/get_predictions_vglm.R
+++ b/R/get_predictions_vglm.R
@@ -41,7 +41,7 @@ get_predictions_vglm <- function(model, fitfram, ci.lvl, linv, ...) {
 
     if (se) {
       dat <- data.frame(predicted = prdat$fitted.values)
-      if(!is_multivariate) {
+      if (!is_multivariate) {
         resp.names <- resp.names[-1]
       }
     } else {

--- a/R/get_predictions_vglm.R
+++ b/R/get_predictions_vglm.R
@@ -4,6 +4,11 @@ get_predictions_vglm <- function(model, fitfram, ci.lvl, linv, ...) {
   se <- !is.null(ci.lvl) && !is.na(ci.lvl)
   mi <- insight::model_info(model)
 
+  is_multivariate <- model@extra$multiple.responses
+  if(is.null(is_multivariate)) {
+    is_multivariate <- FALSE
+  }
+
   # compute ci, two-ways
   if (!is.null(ci.lvl) && !is.na(ci.lvl))
     ci <- (1 + ci.lvl) / 2
@@ -28,8 +33,7 @@ get_predictions_vglm <- function(model, fitfram, ci.lvl, linv, ...) {
     ...
   )
 
-  if (mi$is_ordinal || mi$is_multinomial ||
-      model@extra$multiple.responses == TRUE) {
+  if (mi$is_ordinal || mi$is_multinomial || is_multivariate) {
     # start here with cumulative link models
     resp <- insight::get_response(model)
 
@@ -40,7 +44,7 @@ get_predictions_vglm <- function(model, fitfram, ci.lvl, linv, ...) {
 
     if (se) {
       dat <- data.frame(predicted = prdat$fitted.values)
-      if(model@extra$multiple.responses != TRUE) {
+      if(!is_multivariate) {
         resp.names <- resp.names[-1]
       }
     } else {

--- a/tests/testthat/test-vglm.R
+++ b/tests/testthat/test-vglm.R
@@ -60,3 +60,22 @@ test_that("ggpredict", {
   expect_equal(p$predicted[1], 0.9940077, tolerance = 1e-3)
   expect_identical(nrow(p), 24L)
 })
+
+
+test_that("ggpredict, multivariate vglm", {
+  data("hunua", package = "VGAM")
+  shunua <- hunua[sort.list(with(hunua, altitude)), ]
+
+  fit <- VGAM::vglm(cbind(agaaus, kniexc) ~ altitude,
+    VGAM::binomialff(multiple.responses = TRUE),
+    data = shunua
+  )
+
+  # validate against predict
+  out <- ggpredict(fit, "altitude [all]")
+  nd <- new_data(fit, "altitude [all]")
+  pr <- as.data.frame(predict(fit, newdata = nd))
+
+  expect_equal(out$predicted[c(TRUE, FALSE)], plogis(pr[[1]]), tolerance = 1e-3)
+  expect_equal(out$predicted[c(FALSE, TRUE)], plogis(pr[[2]]), tolerance = 1e-3)
+})


### PR DESCRIPTION
Issue #431 

Checks if multiple responses are expected (`model@extra$multiple.responses == TRUE`) and if so execute same code as for ordinal and multinomial models, except dropping first column name.

`Insight` doesn't return `is_multivariate == TRUE` for `vglm`, so I have accessed the slot directly.