### PR TITLE
Suggestion: Option to specify range of values to use for ggpredict as "full", "95percentile", "90percentile" etc.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: ggeffects
 Type: Package
 Encoding: UTF-8
 Title: Create Tidy Data Frames of Marginal Effects for 'ggplot' from Model Outputs
-Version: 1.6.0.13
+Version: 1.6.0.14
 Authors@R: c(
       person("Daniel", "Lüdecke", role = c("aut", "cre"), email = "d.luedecke@uke.de", comment = c(ORCID = "0000-0002-8895-3206")),
       person("Frederik", "Aust", role = "ctb", comment = c(ORCID = "0000-0003-4900-788X")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -27,6 +27,10 @@
 
 * Improved accuracy of standard errors for `test_predictions(..., engine = "ggeffects")`.
 
+* The `terms` argument now also accepts the shortcut `"percentile"` (plus numeric
+  value) to select a range of percentiles for continuous variables, e.g.
+  `terms = "x [percentile90]"` to select a range of the 90% percentile.
+
 ## Bug fixes
 
 * Fixed issue with *brms* models with monotonic effects in formula (`mo()`).

--- a/R/utils_get_representative_values.R
+++ b/R/utils_get_representative_values.R
@@ -91,7 +91,7 @@
       if (x == "pretty") {
         # return pretty range
         x <- pretty_range(model_frame[[y]])
-      } else if (x %in% at_pattern) {
+      } else if (x %in% at_pattern || startsWith(x, "percentile")) {
         # return at specific values
         x <- values_at(model_frame[[y]], values = x)
       } else {

--- a/man/values_at.Rd
+++ b/man/values_at.Rd
@@ -35,6 +35,9 @@ the moderator value, \emph{excluding} minimum and maximum value.
 the moderator value, \emph{including} minimum and maximum value.
 \item \code{"terciles2"}: calculates and uses the terciles (lower and upper third)
 of the moderator value, \emph{excluding} minimum and maximum value.
+\item an option to compute a range of percentiles is also possible, using
+\code{"percentile"}, followed by the percentage of the range. For example,
+\code{"percentile95"} will calculate the 95\% range of the variable.
 \item \code{"all"}: uses all values of the moderator variable. Note that this option
 only applies to \code{type = "eff"}, for numeric moderator values.
 }}

--- a/tests/testthat/test-percentile_at_values.R
+++ b/tests/testthat/test-percentile_at_values.R
@@ -1,0 +1,27 @@
+skip_on_os(c("mac", "solaris"))
+
+test_that("ggpredict, percentiles", {
+  data(mtcars)
+  m <- lm(mpg ~ hp, data = mtcars)
+  out <- predict_response(m, "hp [percentile90]")
+  expect_equal(
+    out$x,
+    c(
+      63.6, 66, 82.2, 93.4, 96.5, 106.2, 109.8, 110, 112.9, 123,
+      150, 165, 175, 178.5, 180, 200, 220.2, 243.5, 253.5
+    ),
+    tolerance = 1e-4
+  )
+  out <- predict_response(m, "hp [percentile50]")
+  expect_equal(
+    out$x,
+    c(96.5, 106.2, 109.8, 110, 112.9, 123, 150, 165, 175, 178.5, 180),
+    tolerance = 1e-4
+  )
+  expect_message(expect_message(expect_warning(expect_warning(
+    {
+      out <- predict_response(m, "hp [percentileab]")
+    }
+  ))))
+  expect_equal(out$x, c(52, 335), tolerance = 1e-4)
+})

--- a/vignettes/introduction_effectsatvalues.Rmd
+++ b/vignettes/introduction_effectsatvalues.Rmd
@@ -148,6 +148,7 @@ You can use
 * `"quart"` calculates and uses the quartiles (lower, median and upper), _including_ minimum and maximum value.
 * `"quart2"` calculates and uses the quartiles (lower, median and upper), _excluding_ minimum and maximum value.
 * `"fivenum"` calculates Tukey's five-number-summary (minimum, lower-hinge, median, upper-hinge, maximum).
+* `"percentile"` (including the percentile-value) calculates a range of values from the given percentile, e.g. `"percentile80"`.
 * `"all"` takes all values of the vector.
 
 ```{r}


### PR DESCRIPTION
Fixes #145