### PR TITLE
Fix typo

### DIFF
--- a/vignettes/introduction_randomeffects.Rmd
+++ b/vignettes/introduction_randomeffects.Rmd
@@ -58,7 +58,7 @@ callout_tip(
   tags$ul(
     tags$li("Predictions can be made on the population-level or for each level of the grouping variable (unit-level). If unit-level predictions are requested, you need to set ", tags$code("type=\"random\""), " and specify the grouping variable(s) in the ", tags$code("terms"), " argument."), # nolint
     tags$li("Population-level predictions can be either conditional (predictions for a \"typical\" group) or marginal (average predictions across all groups). Set ", tags$code("margin=\"empirical\""), " for marginal predictions. You'll notice differences in predictions especially for unequal group sizes at the random effects level."), # nolint
-    tags$li("Prediction intervals, i.e. when ", tags$code("interval=\"predictions\""), " also account for the uncertainty in the random effects.") # nolint
+    tags$li("Prediction intervals, i.e. when ", tags$code("interval=\"prediction\""), " also account for the uncertainty in the random effects.") # nolint
   )
 )
 ```


### PR DESCRIPTION
I fixed a typo in the vignette (using `interval="predictions"` returns error, `interval="prediction"` does not)