### PR TITLE
Make ggpredict() work with sdmTMB delta models

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -301,12 +301,13 @@ is.gamm4 <- function(x) {
 }
 
 
-.is_delta_sdmTMB <- function(x) {
-  ret <- FALSE
+.check_delta_sdmTMB <- function(x) {
   if (inherits(x, "sdmTMB") && isTRUE(x$family$delta)) {
-    ret <- TRUE
+    if (!"delta_model_predict" %in% names(attributes(x))) {
+      insight::format_error("`ggpredict()` needs `sdmTMB::set_delta_model()` to be set first to work with `sdmTMB` delta models.")
+    }
   }
-  ret
+  invisible(NULL)
 }
 
 

--- a/R/utils_ggpredict.R
+++ b/R/utils_ggpredict.R
@@ -165,9 +165,7 @@
   }
 
   # for sdmTMB objects, delta/hurdle models have family lists
-  if (.is_delta_sdmTMB(model)) {
-    insight::format_error("`ggpredict()` does not yet work with `sdmTMB` delta models.")
-  }
+  .check_delta_sdmTMB(model)
 
   model
 }

--- a/tests/testthat/test-sdmTMB.R
+++ b/tests/testthat/test-sdmTMB.R
@@ -50,7 +50,7 @@ test_that("ggpredict for sdmTMB *with* random fields returns sensible values", {
   expect_error(ggpredict(fit, "depth_scaled [all]", type = "random"), regexp = "supported")
 })
 
-test_that("ggpredict for sdmTMB delta models returns an error for now", {
+test_that("ggpredict for sdmTMB delta models require set_delta_model()", {
   data(pcod_2011, package = "sdmTMB")
   fit <- sdmTMB::sdmTMB(
     density ~ depth_scaled,
@@ -58,7 +58,26 @@ test_that("ggpredict for sdmTMB delta models returns an error for now", {
     spatial = "off",
     family = sdmTMB::delta_gamma()
   )
-  expect_error(ggpredict(fit, "depth_scaled [all]"), regexp = "delta")
+  expect_error(ggpredict(fit, "depth_scaled"), regexp = "set_delta_model")
+
+  fit_binom <- sdmTMB::set_delta_model(fit, model = 1)
+  p_binom <- ggpredict(fit_binom, "depth_scaled [all]")
+  expect_false(anyNA(p_binom$predicted))
+  expect_true(all(is.finite(p_binom$predicted)))
+
+  fit_pos <- sdmTMB::set_delta_model(fit, model = 2)
+  p_pos <- ggpredict(fit_pos, "depth_scaled [all]")
+  expect_false(anyNA(p_pos$predicted))
+  expect_true(all(is.finite(p_pos$predicted)))
+
+  fit_combined <- sdmTMB::set_delta_model(fit, model = NA)
+  p_combined <- ggpredict(fit_combined, "depth_scaled [all]")
+  expect_false(anyNA(p_combined$predicted))
+  expect_true(all(is.finite(p_combined$predicted)))
+
+  expect_false(identical(p_pos$predicted, p_combined$predicted))
+  expect_false(identical(p_binom$predicted, p_combined$predicted))
+  expect_false(identical(p_pos$predicted, p_binom$predicted))
 })
 
 test_that("ggpredict for sdmTMB with IID random intercepts matches glmmTMB", {


### PR DESCRIPTION
Add support for sdmTMB delta/hurdle models in `ggpredict()`. Delta models require `sdmTMB::set_delta_model()` to be called first to specify which linear predictor to predict from. If not set, `ggpredict()` will raise an informative error message via `.check_delta_sdmTMB()`. I've also added unit tests to cover this.