### PR TITLE
get findbars from reformulas rather than lme4

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,8 @@ Imports:
     insight (>= 1.3.0),
     datawizard (>= 1.2.0),
     stats,
-    utils
+    utils, 
+    reformulas
 Suggests:
     AER,
     afex,

--- a/R/predict_zero_inflation.R
+++ b/R/predict_zero_inflation.R
@@ -118,7 +118,6 @@
                                           terms = NULL,
                                           typical = NULL,
                                           condition = NULL) {
-  insight::check_if_installed("lme4")
 
   # Since the zero inflation and the conditional model are working in "opposite
   # directions", confidence intervals can not be derived directly  from the

--- a/R/predict_zero_inflation.R
+++ b/R/predict_zero_inflation.R
@@ -128,8 +128,8 @@
 
   tryCatch(
     {
-      condformula <- lme4::nobars(stats::formula(model)[-2])
-      ziformula <- lme4::nobars(stats::formula(model$modelInfo$allForm$ziformula))
+      condformula <- reformulas::nobars(stats::formula(model)[-2])
+      ziformula <- reformulas::nobars(stats::formula(model$modelInfo$allForm$ziformula))
 
       # if formula has a polynomial term, and this term is one that is held
       # constant, model.matrix() with "newdata" will throw an error - so we


### PR DESCRIPTION
I made `reformulas` Imports: rather than Suggests: (hope that's OK, it didn't seem worth all the conditional testing, and it should be a generally useful tool - and reasonably stable)

The 1.1-38 release of `lme4` will warn when `findbars()` is taken from `lme4` rather than `reformulas` ... the warning-catching stuff in `.simulate_predictions_glmmTMB` then makes this into an error downstream ...